### PR TITLE
Create How to cast OpenCV cv::Mat as Void pointer?

### DIFF
--- a/How to cast OpenCV cv::Mat as Void pointer?
+++ b/How to cast OpenCV cv::Mat as Void pointer?
@@ -1,0 +1,15 @@
+void *set_metadata_ptr(cv::Mat frame)
+{
+
+  cv::Mat *user_metadata = new cv::Mat();
+
+  frame.copyTo(*user_metadata);
+
+  return (void *)user_metadata;
+}
+
+void foo() 
+{
+  UserMeta *user_meta = /* ... */;
+  user_meta->user_meta_data = (void *)set_metadata_ptr(frame);
+}


### PR DESCRIPTION
This works good, but many of the OpenCV power users discourage using pointers with cv::Mat as cv::Mat has smart pointer itself. I wonder is there any better way to cast the cv::Mat as void-pointer in my case?